### PR TITLE
Cache enable and use global storage for instance list

### DIFF
--- a/config/awscronjob.php
+++ b/config/awscronjob.php
@@ -13,4 +13,5 @@ return [
     'skip_environments' => env('AWS_CRON_SKIP_APP_ENV', 'local'),
     'run_on_errors'     => env('AWS_CRON_RUN_ON_ERRORS', true),
     'cache_time'        => env('AWS_CRON_CACHE_TIME', 5),
+    'cache_enabled'     => env('AWS_CRON_CACHE_ENABLED', true),
 ];

--- a/readme.md
+++ b/readme.md
@@ -63,13 +63,15 @@ After that you can setup the package in `config/awscronjob.php`:
 	    'skip_environments' => env('AWS_CRON_SKIP_APP_ENV', 'local'),
 	    'run_on_errors'     => env('AWS_CRON_RUN_ON_ERRORS', true),
 	    'cache_time'        => env('AWS_CRON_CACHE_TIME', 5),
+	    'cache_enabled'     => env('AWS_CRON_CACHE_ENABLED', true),
 	];
 	
 * `connection` AWS region and API version (credentials will be picked from your env by default)
-* `aws_environment` AWS environment name used to filter instances
+* `aws_environment` AWS environment name (used to filter instances by environment name tag)
 * `skip_environments` A comma separated list of Laravel app environments to skip and automatically run cron jobs (default: `local`)
 * `run_on_errors` Should it run cron jobs if an error in communication with AWS servers happens (default: `true`)
 * `cache_time` How long should it cache list of all instanes (in minutes, default: `5`)
+* `cache_enabled` Should we cache instance list and instance id or not (default: `true`)
 
 Since at least `aws_environment` will be different for each of your environments, it is the best not to mess with the published config file too much, but to set up configuration with the following environment variables directly in your Elasticbeanstalk console:
 

--- a/src/Commands/AwsScheduleRunCommand.php
+++ b/src/Commands/AwsScheduleRunCommand.php
@@ -50,13 +50,13 @@ class AwsScheduleRunCommand extends ScheduleRunCommand
 
         $ec2 = new Ec2InstanceInfo(config('awscronjob.connection', []));
 
-        if (Cache::store('file')->has('aws-cronjob-ec2-instances')) {
-            $activeInstances = Cache::store('file')->get('aws-cronjob-ec2-instances');
+        if (Cache::has('aws-cronjob-ec2-instances')) {
+            $activeInstances = Cache::get('aws-cronjob-ec2-instances');
         } else {
             try {
                 $activeInstances = $ec2->allInstanceIds(config('awscronjob.aws_environment', 'production'));
                 if (!empty($activeInstances)) {
-                    Cache::store('file')->put('aws-cronjob-ec2-instances', $activeInstances, config('awscronjob.cache_time', 5));
+                    Cache::put('aws-cronjob-ec2-instances', $activeInstances, config('awscronjob.cache_time', 5));
                 }
             } catch (\Exception $ex) {
                 $activeInstances = [];

--- a/src/Commands/AwsScheduleRunCommand.php
+++ b/src/Commands/AwsScheduleRunCommand.php
@@ -5,6 +5,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Exception;
 
 class AwsScheduleRunCommand extends ScheduleRunCommand
 {
@@ -50,7 +51,7 @@ class AwsScheduleRunCommand extends ScheduleRunCommand
 
         $ec2 = new Ec2InstanceInfo(config('awscronjob.connection', []));
 
-        if (Cache::has('aws-cronjob-ec2-instances')) {
+        if (config('awscronjob.cache_enabled') && Cache::has('aws-cronjob-ec2-instances')) {
             $activeInstances = Cache::get('aws-cronjob-ec2-instances');
         } else {
             try {
@@ -58,7 +59,7 @@ class AwsScheduleRunCommand extends ScheduleRunCommand
                 if (!empty($activeInstances)) {
                     Cache::put('aws-cronjob-ec2-instances', $activeInstances, config('awscronjob.cache_time', 5));
                 }
-            } catch (\Exception $ex) {
+            } catch (Exception $ex) {
                 $activeInstances = [];
                 Log::error($ex->getMessage());
             }
@@ -69,7 +70,7 @@ class AwsScheduleRunCommand extends ScheduleRunCommand
             $this->runIfEnabled();
         }
 
-        if (Cache::store('file')->has('aws-cronjob-ec2-instance-id')) {
+        if (config('awscronjob.cache_enabled') && Cache::store('file')->has('aws-cronjob-ec2-instance-id')) {
             $thisInstance = Cache::store('file')->get('aws-cronjob-ec2-instance-id');
         } else {
             try {
@@ -77,7 +78,7 @@ class AwsScheduleRunCommand extends ScheduleRunCommand
                 if (!empty($thisInstance)) {
                     Cache::store('file')->forever('aws-cronjob-ec2-instance-id', $thisInstance);
                 }
-            } catch (\Exception $ex) {
+            } catch (Exception $ex) {
                 $thisInstance = null;
                 Log::error($ex->getMessage());
             }


### PR DESCRIPTION
I have worked a bit on refactoring the handle function as it is doing a lot of things.  cache_enabled setting option (maybe future you may want two - one to cache instance list and one to cache instanceid but with a global store issue wont exist of dual crons running)